### PR TITLE
Move off of :java

### DIFF
--- a/Formula/bazel@2.2.0.rb
+++ b/Formula/bazel@2.2.0.rb
@@ -12,7 +12,7 @@ class BazelAT220 < Formula
   end
 
   depends_on "python@3.8" => :build
-  depends_on :java => "1.8"
+  depends_on "openjdk@8"
   depends_on :macos => :yosemite
 
   uses_from_macos "zip"

--- a/Formula/gdal.rb
+++ b/Formula/gdal.rb
@@ -77,7 +77,7 @@ class Gdal < Formula
     depends_on "json-c"
   end
 
-  depends_on :java => ["1.7+", :optional, :build]
+  depends_on "openjdk@8"
 
   if build.with? "swig-java"
     depends_on "ant" => :build


### PR DESCRIPTION
Here are the errors me and Kevin are seeing:
```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/codebutler/homebrew-brew/Formula/gdal.rb
gdal: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the codebutler/brew tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/codebutler/homebrew-brew/Formula/gdal.rb:80

Warning: Calling depends_on :osxfuse is deprecated! There is no replacement.
Please report this issue to the codebutler/brew tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/codebutler/homebrew-brew/Formula/fuse-ext2.rb:11

Error: Invalid formula: /usr/local/Homebrew/Library/Taps/codebutler/homebrew-brew/Formula/bazel@2.2.0.rb
bazel@2.2.0: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the codebutler/brew tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/codebutler/homebrew-brew/Formula/bazel@2.2.0.rb:15

Error: Cannot tap codebutler/brew: invalid syntax in tap!
```